### PR TITLE
Correct suspend function which returns array

### DIFF
--- a/retrosheet/src/main/kotlin/com/github/theapache64/retrosheet/RetrosheetInterceptor.kt
+++ b/retrosheet/src/main/kotlin/com/github/theapache64/retrosheet/RetrosheetInterceptor.kt
@@ -100,7 +100,11 @@ private constructor(
 
             val matchedValue = regex.find(typeName) ?: return false // Not matched -> not suspend method
             val suspendFunReturnType = matchedValue.groupValues.last()
-            val clazz = Class.forName(suspendFunReturnType)
+            return isArrayOrCollectionClass(suspendFunReturnType)
+        }
+
+        private fun isArrayOrCollectionClass(classQualifiedName: String): Boolean {
+            val clazz = Class.forName(classQualifiedName)
             return clazz.isArray || Collection::class.java.isAssignableFrom(clazz)
         }
     }


### PR DESCRIPTION
In #12, I was wrong when checking the return value is an array.
`Class.forName("className")` does not return an Array class (`class.isArray` is always false).
With this PR, I try to fix this by checking whether `actualTypeArguments.firstOrNull().typeName` ends with `[]`.

Besides, I also update the code for checking `Continuation` in the return type. Instead of checking from typeName string, we can make it more reliable by comparing it with `lastParameter.rawType.typeName`.