### PR TITLE
Refactor CsvConverter

### DIFF
--- a/retrosheet/src/main/kotlin/com/github/theapache64/retrosheet/utils/CsvConverter.kt
+++ b/retrosheet/src/main/kotlin/com/github/theapache64/retrosheet/utils/CsvConverter.kt
@@ -15,48 +15,46 @@ object CsvConverter {
         csvData: String,
         isReturnTypeList: Boolean
     ): String? {
-        return csvReader.parse(csvData.reader()).use { csvParser ->
-            val items = mutableListOf<Map<String, Any?>>()
-
-            for (row in csvParser.asIterator()) {
-                val item = csvParser.header.associateWith { key ->
-                    val field = row.getField(key)
-                    @Suppress("IMPLICIT_CAST_TO_ANY")
-                    when {
-                        field == null -> null
-                        TypeIdentifier.isInteger(field) -> field.toLong()
-                        TypeIdentifier.isBoolean(field) -> field.toBoolean()
-                        TypeIdentifier.isDouble(field) -> field.toDouble()
-                        else -> field.takeUnless { it.isBlank() }
+        val items = csvReader.parse(csvData.reader()).use { csvParser ->
+            csvParser
+                .asIterator()
+                .asSequence()
+                .map { row ->
+                    csvParser.header.associateWith { key ->
+                        val field = row.getField(key)
+                        @Suppress("IMPLICIT_CAST_TO_ANY")
+                        when {
+                            field == null -> null
+                            TypeIdentifier.isInteger(field) -> field.toLong()
+                            TypeIdentifier.isBoolean(field) -> field.toBoolean()
+                            TypeIdentifier.isDouble(field) -> field.toDouble()
+                            else -> field.takeUnless { it.isBlank() }
+                        }
                     }
                 }
+                .toList()
+        }
 
-                items.add(item)
+        return when {
+            isReturnTypeList -> {
+                val type = Types.newParameterizedType(List::class.java, Map::class.java)
+                val adapter = MoshiUtils.moshi.adapter<List<Map<String, Any?>>>(type)
+                adapter.toJson(items)
             }
 
-            when {
-                isReturnTypeList -> {
-                    val type = Types.newParameterizedType(List::class.java, Map::class.java)
-                    val adapter = MoshiUtils.moshi.adapter<List<Map<String, Any?>>>(type)
-                    adapter.toJson(items)
-                }
-
-                items.isNotEmpty() -> {
-                    val type = Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java)
-                    val adapter = MoshiUtils.moshi.adapter<Map<String, Any?>>(type)
-                    adapter.toJson(items.first())
-                }
-
-                else -> {
-                    null
-                }
+            items.isNotEmpty() -> {
+                val type = Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java)
+                val adapter = MoshiUtils.moshi.adapter<Map<String, Any?>>(type)
+                adapter.toJson(items.first())
             }
+
+            else -> null
         }
     }
 
     private fun CsvParser.asIterator(): Iterator<CsvRow> = CsvRowIterator(this)
 
-    private class CsvRowIterator(private val csvParser: CsvParser): Iterator<CsvRow> {
+    private class CsvRowIterator(private val csvParser: CsvParser) : Iterator<CsvRow> {
         private var row = csvParser.nextRow()
 
         override fun hasNext(): Boolean {

--- a/retrosheet/src/main/kotlin/com/github/theapache64/retrosheet/utils/CsvConverter.kt
+++ b/retrosheet/src/main/kotlin/com/github/theapache64/retrosheet/utils/CsvConverter.kt
@@ -1,61 +1,39 @@
 package com.github.theapache64.retrosheet.utils
 
 import com.squareup.moshi.Types
+import de.siegmar.fastcsv.reader.CsvParser
 import de.siegmar.fastcsv.reader.CsvReader
+import de.siegmar.fastcsv.reader.CsvRow
 
 /**
  * Created by theapache64 : Jul 22 Wed,2020 @ 00:05
  */
 object CsvConverter {
+    private val csvReader: CsvReader = CsvReader().apply { setContainsHeader(true) }
+
     fun convertCsvToJson(
         csvData: String,
         isReturnTypeList: Boolean
     ): String? {
-        return CsvReader().apply {
-            setContainsHeader(true)
-        }.parse(csvData.reader()).use {
+        return csvReader.parse(csvData.reader()).use { csvParser ->
+            val items = mutableListOf<Map<String, Any?>>()
 
-            // Parsing CSV
-            val items = mutableListOf<Map<String, Any?>>().apply {
-                // Loading headers first
-                while (true) {
-                    val row = it.nextRow() ?: break
-                    val item = mutableMapOf<String, Any?>().apply {
-                        for (header in it.header) {
-                            val field = row.getField(header)
-                            when {
-                                TypeIdentifier.isInteger(
-                                    field
-                                ) -> {
-                                    put(header, field.toLong())
-                                }
-
-                                TypeIdentifier.isBoolean(
-                                    field
-                                ) -> {
-                                    put(header, field!!.toBoolean())
-                                }
-
-                                TypeIdentifier.isDouble(
-                                    field
-                                ) -> {
-                                    put(header, field.toDouble())
-                                }
-
-                                else -> {
-                                    val finalValue = if (field.isNullOrBlank()) {
-                                        null
-                                    } else {
-                                        field
-                                    }
-                                    put(header, finalValue)
-                                }
-                            }
-                        }
+            for (row in csvParser.asIterator()) {
+                val item = csvParser.header.associateWith { key ->
+                    val field = row.getField(key)
+                    @Suppress("IMPLICIT_CAST_TO_ANY")
+                    when {
+                        field == null -> null
+                        TypeIdentifier.isInteger(field) -> field.toLong()
+                        TypeIdentifier.isBoolean(field) -> field.toBoolean()
+                        TypeIdentifier.isDouble(field) -> field.toDouble()
+                        else -> field.takeUnless { it.isBlank() }
                     }
-                    add(item)
                 }
+
+                items.add(item)
             }
+
             when {
                 isReturnTypeList -> {
                     val type = Types.newParameterizedType(List::class.java, Map::class.java)
@@ -73,6 +51,22 @@ object CsvConverter {
                     null
                 }
             }
+        }
+    }
+
+    private fun CsvParser.asIterator(): Iterator<CsvRow> = CsvRowIterator(this)
+
+    private class CsvRowIterator(private val csvParser: CsvParser): Iterator<CsvRow> {
+        private var row = csvParser.nextRow()
+
+        override fun hasNext(): Boolean {
+            return row != null
+        }
+
+        override fun next(): CsvRow {
+            val currentRow = row!!
+            row = csvParser.nextRow()
+            return currentRow
         }
     }
 }


### PR DESCRIPTION
I reduce the size of `.use` scope by converting csv reader into iterator then to sequence and we can use `map{}`.
I also cut the mapping if the return value is not a list.